### PR TITLE
feat >> 중고거래/무료나눔 페이지 + 서치 페이지 무한 스크롤 적용했습니다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 # misc
 .env
 .DS_Store
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/apis/core.js
+++ b/src/apis/core.js
@@ -63,4 +63,3 @@ axiosInstance.interceptors.response.use(
 );
 
 */
-

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -5,20 +5,22 @@ const getAllProduct = async () => {
   return res.data;
 };
 
-
 const getDetailProduct = async (param) => {
   const res = await axiosInstance.get(`/api/product/detail?prod_idx=${param}`);
   return res.data;
 };
 
-
-const getUsedOrFreeProduct = async (param) => {
-  const res = await axiosInstance.get(`/products/${param}`);
+const getUsedOrFreeProduct = async (pageParam, saleStatus) => {
+  const res = await axiosInstance.get(
+    `/api/product/search?category=${saleStatus}&page=${pageParam}`
+  );
   return res.data;
 };
 
-const getSearchProduct = async (category, keyword, page) => {
-  const res = await axiosInstance.get(`/api/product/search?category=${category}&keyword=${keyword}&page=${page}`);
+const getSearchProduct = async (category, keyword, pageParam) => {
+  const res = await axiosInstance.get(
+    `/api/product/search?category=${category}&keyword=${keyword}&page=${pageParam}`
+  );
   return res.data;
 };
 

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -42,8 +42,8 @@ const Header = () => {
       <S.LeftContainer>
         <S.HeaderLogoIcon src={BlackLogo} alt="Logo" onClick={onGoMainPage} />
         <S.Ul>
-          <li onClick={() => onGoProductsListPage("sell")}>중고거래</li>
-          <li onClick={() => onGoProductsListPage("free")}>무료나눔</li>
+          <li onClick={() => onGoProductsListPage("0")}>중고거래</li>
+          <li onClick={() => onGoProductsListPage("1")}>무료나눔</li>
           <li onClick={onGoPriceCheckPage}>시세조회</li>
         </S.Ul>
       </S.LeftContainer>

--- a/src/components/one-product.js
+++ b/src/components/one-product.js
@@ -1,195 +1,207 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router';
-import styled from 'styled-components';
-import { flexCenter } from 'styles/common.style';
-import HeartIcon from '../images/icon/fullheart.png';
-import emptyHeartIcon from '../images/icon/emptyHeart.png';
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import styled from "styled-components";
+import { flexCenter } from "styles/common.style";
+import HeartIcon from "../images/icon/fullheart.png";
+import emptyHeartIcon from "../images/icon/emptyHeart.png";
 
-const OneProduct = ({ title, status, img, price, id, description }) => {
-    const navigate = useNavigate();
-    const [isLiked, setIsLiked] = useState(false);
+const OneProduct = ({ title, status, img, price, id, likeCount }) => {
+  const navigate = useNavigate();
+  const [isLiked, setIsLiked] = useState(false);
 
-    const onClickToDetailPage = (id) => {
-        navigate(`/products/detail/${id}`);
-        window.scrollTo({ top: 0 });
-    };
+  const onClickToDetailPage = (id) => {
+    navigate(`/products/detail/${id}`);
+    window.scrollTo({ top: 0 });
+  };
 
-    const onToggleIsLiked = () => {
-        setIsLiked((prev) => !prev);
-    };
+  const onToggleIsLiked = () => {
+    setIsLiked((prev) => !prev);
+  };
 
-    return (
-        <S.Wrapper>
-            {status === '판매중' ? (
-                <S.ProductImg src={img} alt="product img" onClick={() => onClickToDetailPage(id)} />
-            ) : (
-                <>
-                    <S.SoldOutProductImg src={img} alt="product img" onClick={() => onClickToDetailPage(id)} />
-                    <S.SoldOutMessage>Sold Out</S.SoldOutMessage>
-                </>
-            )}
-            <S.TitleAndLikeBox>
-                <S.Title className="Title">{title}</S.Title>
+  return (
+    <S.Wrapper>
+      {status === "판매중" ? (
+        <S.ProductImg
+          src={img}
+          alt="product img"
+          onClick={() => onClickToDetailPage(id)}
+        />
+      ) : (
+        <>
+          <S.SoldOutProductImg
+            src={img}
+            alt="product img"
+            onClick={() => onClickToDetailPage(id)}
+          />
+          <S.SoldOutMessage>Sold Out</S.SoldOutMessage>
+        </>
+      )}
+      <S.TitleAndLikeBox>
+        <S.Title className="Title">{title}</S.Title>
 
-                {isLiked ? (
-                    <S.HeartImg src={HeartIcon} alt="heart" onClick={onToggleIsLiked} />
-                ) : (
-                    <S.HeartImg src={emptyHeartIcon} alt="emptyHeart" onClick={onToggleIsLiked} />
-                )}
-            </S.TitleAndLikeBox>
-            <S.Content className="Content">{description}</S.Content>
-            <S.Price className="Price">{price}원</S.Price>
-        </S.Wrapper>
-    );
+        {isLiked ? (
+          <S.HeartImg src={HeartIcon} alt="heart" onClick={onToggleIsLiked} />
+        ) : (
+          <S.HeartImg
+            src={emptyHeartIcon}
+            alt="emptyHeart"
+            onClick={onToggleIsLiked}
+          />
+        )}
+      </S.TitleAndLikeBox>
+      <S.Content className="Content">{likeCount}명이 관심 있어요!</S.Content>
+      <S.Price className="Price">{price}원</S.Price>
+    </S.Wrapper>
+  );
 };
 
 export default OneProduct;
 
 const Wrapper = styled.div`
-    ${flexCenter};
-    flex-direction: column;
-    position: relative;
-    @media screen and (min-width: 1023px) {
-        width: 290px;
-    }
-    &:hover {
-        cursor: pointer;
-        box-shadow: 3px 3px 3px 3px ${({ theme }) => theme.COLORS.gray[100]};
-        transform: translateY(-8px);
-        transition: all ease 0.2s;
-        border-radius: 10px;
-    }
+  ${flexCenter};
+  flex-direction: column;
+  position: relative;
+  @media screen and (min-width: 1023px) {
+    width: 290px;
+  }
+  &:hover {
+    cursor: pointer;
+    box-shadow: 3px 3px 3px 3px ${({ theme }) => theme.COLORS.gray[100]};
+    transform: translateY(-8px);
+    transition: all ease 0.2s;
+    border-radius: 10px;
+  }
 
-    .content {
-        @media ${({ theme }) => theme.DEVICE.mobile} {
-            width: 50%;
-        }
-        @media ${({ theme }) => theme.DEVICE.tablet} {
-            width: 50%;
-        }
+  .content {
+    @media ${({ theme }) => theme.DEVICE.mobile} {
+      width: 50%;
     }
+    @media ${({ theme }) => theme.DEVICE.tablet} {
+      width: 50%;
+    }
+  }
 `;
 
 const ProductImg = styled.img`
-    width: 280px;
-    height: 280px;
-    border-radius: 16px;
+  width: 280px;
+  height: 280px;
+  border-radius: 16px;
 
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        width: 90%;
-        height: 90%;
-    }
-    @media ${({ theme }) => theme.DEVICE.tablet} {
-        width: 90%;
-        height: 90%;
-    }
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    width: 90%;
+    height: 90%;
+  }
+  @media ${({ theme }) => theme.DEVICE.tablet} {
+    width: 90%;
+    height: 90%;
+  }
 `;
 
 const SoldOutProductImg = styled.img`
-    width: 280px;
-    height: 280px;
-    border-radius: 16px;
-    filter: contrast(15%);
+  width: 280px;
+  height: 280px;
+  border-radius: 16px;
+  filter: contrast(15%);
 
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        width: 90%;
-        height: 90%;
-    }
-    @media ${({ theme }) => theme.DEVICE.tablet} {
-        width: 90%;
-        height: 90%;
-    }
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    width: 90%;
+    height: 90%;
+  }
+  @media ${({ theme }) => theme.DEVICE.tablet} {
+    width: 90%;
+    height: 90%;
+  }
 `;
 
 const SoldOutMessage = styled.div`
-    position: absolute;
-    top: 125px;
-    font-size: ${({ theme }) => theme.FONT_SIZE['extraLarge']};
-    font-weight: ${({ theme }) => theme.FONT_WEIGHT['bold']};
-    color: ${({ theme }) => theme.COLORS['white']};
+  position: absolute;
+  top: 125px;
+  font-size: ${({ theme }) => theme.FONT_SIZE["extraLarge"]};
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT["bold"]};
+  color: ${({ theme }) => theme.COLORS["white"]};
 `;
 
 const TitleAndLikeBox = styled.div`
-    padding: 10px 0 10px 0;
-    width: 280px;
-    display: flex;
-    justify-content: space-between;
+  padding: 10px 0 10px 0;
+  width: 280px;
+  display: flex;
+  justify-content: space-between;
 
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        width: 90%;
-    }
-    @media ${({ theme }) => theme.DEVICE.tablet} {
-        width: 90%;
-    }
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    width: 90%;
+  }
+  @media ${({ theme }) => theme.DEVICE.tablet} {
+    width: 90%;
+  }
 `;
 
 const Title = styled.div`
-    font-size: ${({ theme }) => theme.FONT_SIZE.medium};
-    font-weight: ${({ theme }) => theme.FONT_WEIGHT.regular};
-    width: 200px;
-    height: 18px;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
-    word-wrap: break-word;
-    overflow: hidden;
-    padding-bottom: px;
+  font-size: ${({ theme }) => theme.FONT_SIZE.medium};
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT.regular};
+  width: 200px;
+  height: 18px;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  word-wrap: break-word;
+  overflow: hidden;
+  padding-bottom: px;
 `;
 
 const HeartImg = styled.img`
-    width: 20px;
+  width: 20px;
 `;
 
 const Content = styled.div`
-    font-size: ${({ theme }) => theme.FONT_SIZE.extraSmall};
-    font-weight: ${({ theme }) => theme.FONT_WEIGHT.light};
-    color: ${({ theme }) => theme.COLORS.gray[400]};
-    padding-top: 5px;
-    width: 280px;
-    height: 65px;
-    line-height: 1.2;
-    display: flex;
-    justify-content: flex-start;
-    height: 36px;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
-    word-wrap: break-word;
-    overflow: hidden;
+  font-size: ${({ theme }) => theme.FONT_SIZE.extraSmall};
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT.light};
+  color: ${({ theme }) => theme.COLORS.gray[400]};
+  padding-top: 5px;
+  width: 280px;
+  height: 65px;
+  line-height: 1.2;
+  display: flex;
+  justify-content: flex-start;
+  height: 36px;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  word-wrap: break-word;
+  overflow: hidden;
 
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        width: 90%;
-    }
-    @media ${({ theme }) => theme.DEVICE.tablet} {
-        width: 90%;
-    }
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    width: 90%;
+  }
+  @media ${({ theme }) => theme.DEVICE.tablet} {
+    width: 90%;
+  }
 `;
 
 const Price = styled.div`
-    font-size: ${({ theme }) => theme.FONT_SIZE.large};
-    font-weight: ${({ theme }) => theme.FONT_WEIGHT.bold};
-    width: 280px;
-    display: flex;
-    justify-content: flex-start;
-    padding-top: 10px;
-    padding-bottom: 30px;
+  font-size: ${({ theme }) => theme.FONT_SIZE.large};
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT.bold};
+  width: 280px;
+  display: flex;
+  justify-content: flex-start;
+  padding-top: 10px;
+  padding-bottom: 30px;
 
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        width: 90%;
-    }
-    @media ${({ theme }) => theme.DEVICE.tablet} {
-        width: 90%;
-    }
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    width: 90%;
+  }
+  @media ${({ theme }) => theme.DEVICE.tablet} {
+    width: 90%;
+  }
 `;
 
 const S = {
-    Wrapper,
-    ProductImg,
-    TitleAndLikeBox,
-    Content,
-    Price,
-    Title,
-    HeartImg,
-    SoldOutProductImg,
-    SoldOutMessage,
+  Wrapper,
+  ProductImg,
+  TitleAndLikeBox,
+  Content,
+  Price,
+  Title,
+  HeartImg,
+  SoldOutProductImg,
+  SoldOutMessage,
 };

--- a/src/pages/home-page/components/product-list.js
+++ b/src/pages/home-page/components/product-list.js
@@ -1,103 +1,129 @@
-import styled from 'styled-components';
-import OneProduct from 'components/one-product';
-import { useQuery } from 'react-query';
-import { PRODUCT_QUERY_KEY } from 'consts';
-import { Api } from 'apis';
-import { useNavigate } from 'react-router';
-import { Container, Grid } from '@mui/material';
-import MMMButton from 'components/button';
+import styled from "styled-components";
+import OneProduct from "components/one-product";
+import { useQuery } from "react-query";
+import { PRODUCT_QUERY_KEY } from "consts";
+import { Api } from "apis";
+import { useNavigate } from "react-router";
+import { Container, Grid } from "@mui/material";
+import MMMButton from "components/button";
 
 const ProductList = () => {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const { data: productList } = useQuery([PRODUCT_QUERY_KEY.MORE_PRODUCT_LIST], () => Api.getAllProduct());
+  const { data: productList } = useQuery(
+    [PRODUCT_QUERY_KEY.MORE_PRODUCT_LIST],
+    () => Api.getAllProduct()
+  );
 
-    const { data: detailProductList } = useQuery([PRODUCT_QUERY_KEY.DETAIL_PRODUCT_DATA], () =>
-        Api.getDetailProduct('1050')
-    );
+  const { data: detailProductList } = useQuery(
+    [PRODUCT_QUERY_KEY.DETAIL_PRODUCT_DATA],
+    () => Api.getDetailProduct("1050")
+  );
 
-    const UsedProductList = productList && productList.usedProduct;
-    const FreeProductList = productList && productList.freeProduct;
+  const UsedProductList = productList && productList.usedProduct;
+  const FreeProductList = productList && productList.freeProduct;
 
-    const onClickMoreBtn = (saleStatus) => {
-        navigate(`/products/${saleStatus}`);
-    };
+  const onClickMoreBtn = (saleStatus) => {
+    navigate(`/products/${saleStatus}`);
+  };
 
-    return (
-        UsedProductList &&
-        FreeProductList && (
-            <Container>
-                <S.UsedTrade>
-                    <S.Title>중고거래</S.Title>
-                    <Grid container spacing={{ xs: 1, md: 2, lg: 3 }} style={{ paddingBottom: 20 }}>
-                        {UsedProductList.slice(0, 8).map((item, index) => (
-                            <Grid key={index} item xs={12} md={4} lg={3} style={{ paddingBottom: 40 }}>
-                                <OneProduct
-                                    title={item.title}
-                                    content={item.content}
-                                    img={item.img_url}
-                                    price={item.price}
-                                    isLiked={item.isLiked}
-                                    id={item.id}
-                                />
-                            </Grid>
-                        ))}
-                    </Grid>
-                    <MMMButton
-                        onClick={() => onClickMoreBtn('sell')}
-                        variant={'More'}
-                        style={{ border: '1px solid #9F9EB3' }}
-                    >
-                        MORE
-                    </MMMButton>
-                </S.UsedTrade>
-                <S.Share>
-                    <Title>무료나눔</Title>
+  return (
+    UsedProductList &&
+    FreeProductList && (
+      <Container>
+        <S.UsedTrade>
+          <S.Title>중고거래</S.Title>
+          <Grid
+            container
+            spacing={{ xs: 1, md: 2, lg: 3 }}
+            style={{ paddingBottom: 20 }}
+          >
+            {UsedProductList.slice(0, 8).map((item, index) => (
+              <Grid
+                key={index}
+                item
+                xs={12}
+                md={4}
+                lg={3}
+                style={{ paddingBottom: 40 }}
+              >
+                <OneProduct
+                  title={item.title}
+                  content={item.content}
+                  img={item.img_url}
+                  price={item.price}
+                  isLiked={item.isLiked}
+                  id={item.id}
+                />
+              </Grid>
+            ))}
+          </Grid>
+          <MMMButton
+            onClick={() => onClickMoreBtn("0")}
+            variant={"More"}
+            style={{ border: "1px solid #9F9EB3" }}
+          >
+            MORE
+          </MMMButton>
+        </S.UsedTrade>
+        <S.Share>
+          <Title>무료나눔</Title>
 
-                    <Grid container spacing={{ xs: 1, md: 2, lg: 3 }} style={{ paddingBottom: 20 }}>
-                        {FreeProductList.slice(0, 8).map((item, index) => (
-                            <Grid key={index} item xs={12} md={4} lg={3} style={{ paddingBottom: 40 }}>
-                                <OneProduct
-                                    title={item.title}
-                                    content={item.content}
-                                    img={item.img_url}
-                                    price={item.price}
-                                    isLiked={item.isLiked}
-                                    id={item.id}
-                                />
-                            </Grid>
-                        ))}
-                    </Grid>
-                    <MMMButton
-                        onClick={() => onClickMoreBtn('free')}
-                        variant={'More'}
-                        style={{ border: '1px solid #9F9EB3' }}
-                    >
-                        MORE
-                    </MMMButton>
-                </S.Share>
-            </Container>
-        )
-    );
+          <Grid
+            container
+            spacing={{ xs: 1, md: 2, lg: 3 }}
+            style={{ paddingBottom: 20 }}
+          >
+            {FreeProductList.slice(0, 8).map((item, index) => (
+              <Grid
+                key={index}
+                item
+                xs={12}
+                md={4}
+                lg={3}
+                style={{ paddingBottom: 40 }}
+              >
+                <OneProduct
+                  title={item.title}
+                  content={item.content}
+                  img={item.img_url}
+                  price={item.price}
+                  isLiked={item.isLiked}
+                  id={item.id}
+                />
+              </Grid>
+            ))}
+          </Grid>
+          <MMMButton
+            onClick={() => onClickMoreBtn("1")}
+            variant={"More"}
+            style={{ border: "1px solid #9F9EB3" }}
+          >
+            MORE
+          </MMMButton>
+        </S.Share>
+      </Container>
+    )
+  );
 };
 
 export default ProductList;
 
 const Title = styled.h1`
-    font-size: 26px;
-    font-weight: bold;
-    padding: 30px 0;
-    left: 0;
+  font-size: 26px;
+  font-weight: bold;
+  padding: 30px 0;
+  left: 0;
 `;
 
 const Share = styled.div``;
 
 const UsedTrade = styled.div`
-    margin-bottom: 50px;
+  margin-bottom: 50px;
 `;
 
 const S = {
-    UsedTrade,
-    Title,
-    Share,
+  UsedTrade,
+  Title,
+  Share,
 };

--- a/src/pages/product-list-page/component/product-list.js
+++ b/src/pages/product-list-page/component/product-list.js
@@ -1,45 +1,85 @@
-import { Api } from 'apis';
-import { useInfiniteQuery, useQuery } from 'react-query';
-import { useParams } from 'react-router-dom';
-import { PRODUCT_QUERY_KEY } from 'consts';
-import { flexCenter } from 'styles/common.style';
-import styled from 'styled-components';
-import ProductPageTitle from './product-page-title';
-import OneProduct from 'components/one-product';
-import { Container, Grid } from '@mui/material';
+import { Api } from "apis";
+import { useInfiniteQuery, useQuery } from "react-query";
+import { useParams } from "react-router-dom";
+import { PRODUCT_QUERY_KEY } from "consts";
+import { flexCenter } from "styles/common.style";
+import styled from "styled-components";
+import ProductPageTitle from "./product-page-title";
+import OneProduct from "components/one-product";
+import { Container, Grid } from "@mui/material";
+import MMMButton from "components/button";
 
 const ProductList = () => {
-    const { saleStatus } = useParams();
+  const { saleStatus } = useParams();
 
-    const { data: productList } = useQuery([PRODUCT_QUERY_KEY.MORE_PRODUCT_LIST, saleStatus], () =>
-        Api.getAllProduct() 
-    );
-
-    let currentProductList = null;
-
-    if (productList) {
-        currentProductList = saleStatus === 'sell' ? productList.usedProduct : productList.freeProduct;
+  const { data: productList, fetchNextPage } = useInfiniteQuery(
+    [PRODUCT_QUERY_KEY.MORE_PRODUCT_LIST, saleStatus],
+    ({ pageParam = 1 }) => Api.getUsedOrFreeProduct(pageParam, saleStatus),
+    {
+      getNextPageParam: (lastPage) => {
+        return (
+          lastPage.pagination.curPage < lastPage.pagination.totalPage &&
+          lastPage.pagination.curPage + 1
+        );
+      },
     }
-
-    productList && console.log(productList);
+  );
+  productList && console.log(productList.pages);
 
   return (
-    currentProductList && (
+    productList && (
       <S.Wrapper>
         <S.TitleWrapper>
-          <ProductPageTitle totalProductsCount={currentProductList.length} />
+          <ProductPageTitle
+            totalProductsCount={productList.pages[0].pagination.count}
+          />
         </S.TitleWrapper>
         <hr />
         <Container style={{ marginTop: 100 }}>
-          <Grid container spacing={{ xs: 1, md: 2, lg: 3 }} style={{ paddingBottom: 20 }}>
-            {currentProductList.map((product, index) => (
-              <Grid key={index} product xs={12} md={4} lg={3} style={{ paddingBottom: 40 }}>
-                <OneProduct title={product.title} status={product.status} img={product.img_url} price={product.price} isLiked={product.isLiked} id={product.id} />
-              </Grid>
+          <Grid
+            container
+            spacing={{ xs: 1, md: 2, lg: 3 }}
+            style={{ paddingBottom: 20 }}
+          >
+            {productList.pages?.map((page) => (
+              <>
+                {page.product?.map((product, index) => (
+                  <Grid
+                    key={index}
+                    product
+                    xs={12}
+                    md={4}
+                    lg={3}
+                    style={{ paddingBottom: 40 }}
+                  >
+                    <OneProduct
+                      title={product.title}
+                      status={product.status}
+                      img={product.img_url}
+                      price={product.price}
+                      isLiked={product.isLiked}
+                      id={product.id}
+                      likeCount={product.likeCount}
+                    />
+                  </Grid>
+                ))}
+              </>
             ))}
           </Grid>
         </Container>
-        <S.MoreBtn>More</S.MoreBtn>
+        {/* 더 이상 불러올 상품이 없다면 MORE 버튼 안보이게 하는 조건 */}
+        {!(
+          productList.pages.at(-1).pagination.curPage ===
+          productList.pages[0].pagination.endPage
+        ) && (
+          <MMMButton
+            variant={"More"}
+            style={{ border: "1px solid #9F9EB3" }}
+            onClick={() => fetchNextPage()}
+          >
+            More
+          </MMMButton>
+        )}
       </S.Wrapper>
     )
   );
@@ -48,34 +88,34 @@ const ProductList = () => {
 export default ProductList;
 
 const Wrapper = styled.div`
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        padding-top: 80px;
-    }
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    padding-top: 80px;
+  }
 `;
 
 const TitleWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-    max-width: 1165px;
-    margin: 0 auto;
-    padding-top: 36px;
+  display: flex;
+  justify-content: space-between;
+  max-width: 1165px;
+  margin: 0 auto;
+  padding-top: 36px;
 `;
 
 const MoreBtn = styled.button`
-    ${flexCenter};
-    width: fit-content;
-    margin: 0 auto;
-    color: rgba(16, 13, 69, 0.7); //#100d45
-    font-size: ${({ theme }) => theme.FONT_SIZE.extraSmall};
-    border: 1px solid rgba(16, 13, 69, 0.7);
-    background-color: #fff;
-    border-radius: 8px;
-    padding: 8px 28px;
-    margin: 50px auto;
+  ${flexCenter};
+  width: fit-content;
+  margin: 0 auto;
+  color: rgba(16, 13, 69, 0.7); //#100d45
+  font-size: ${({ theme }) => theme.FONT_SIZE.extraSmall};
+  border: 1px solid rgba(16, 13, 69, 0.7);
+  background-color: #fff;
+  border-radius: 8px;
+  padding: 8px 28px;
+  margin: 50px auto;
 `;
 
 const S = {
-    TitleWrapper,
-    MoreBtn,
-    Wrapper,
+  TitleWrapper,
+  MoreBtn,
+  Wrapper,
 };

--- a/src/pages/product-list-page/component/product-page-title.js
+++ b/src/pages/product-list-page/component/product-page-title.js
@@ -8,7 +8,7 @@ const ProductPageTitle = ({ totalProductsCount }) => {
   return (
     // saleStatus에 따라서 중고거래와 무료나눔으로 바꿈
     <S.TitleContainer>
-      {productPageTitle === "sell" ? (
+      {productPageTitle === "0" ? (
         <S.Title>중고거래</S.Title>
       ) : (
         <S.Title>무료나눔</S.Title>

--- a/src/pages/search-page/components/search-product-list.js
+++ b/src/pages/search-page/components/search-product-list.js
@@ -1,94 +1,131 @@
-import { worker } from '__mock__/browser';
-import { Api } from 'apis';
-import OneProduct from 'components/one-product';
-import { PRODUCT_QUERY_KEY } from 'consts';
-import { useQuery } from 'react-query';
-import { useParams, useSearchParams } from 'react-router-dom';
-import styled from 'styled-components';
-import { Container, Grid } from '@mui/material';
-import NoResultPage from './no-result-page';
-import SearchPageTitle from './search-page-title';
+import { Api } from "apis";
+import OneProduct from "components/one-product";
+import { PRODUCT_QUERY_KEY } from "consts";
+import { useInfiniteQuery, useQuery } from "react-query";
+import { useParams, useSearchParams } from "react-router-dom";
+import styled from "styled-components";
+import { Container, Grid } from "@mui/material";
+import NoResultPage from "./no-result-page";
+import SearchPageTitle from "./search-page-title";
+import MMMButton from "components/button";
 
 const SearchProductList = () => {
-    if (process.env.NODE_ENV === 'development') {
-        worker.start();
+  const { searchValue } = useParams();
+
+  const { data: searchUsedProducts, fetchNextPage } = useInfiniteQuery(
+    [PRODUCT_QUERY_KEY.MORE_PRODUCT_LIST, searchValue],
+    ({ pageParam = 1 }) => Api.getSearchProduct(0, searchValue, pageParam),
+    {
+      getNextPageParam: (lastPage) => {
+        return (
+          lastPage.pagination.curPage < lastPage.pagination.totalPage &&
+          lastPage.pagination.curPage + 1
+        );
+      },
     }
+  );
+  searchUsedProducts && console.log(searchUsedProducts);
 
+  return (
+    searchUsedProducts && (
+      <S.Wrapper>
+        {searchUsedProducts.pages[0].product.length === 0 ||
+        searchValue === 194191464161616511 ? (
+          <NoResultPage />
+        ) : (
+          <>
+            <S.TitleWrapper>
+              <SearchPageTitle
+                totalProductsCount={
+                  searchUsedProducts.pages[0].pagination.count
+                }
+                searchValue={searchValue}
+              />
+            </S.TitleWrapper>
+            <hr />
+          </>
+        )}
 
-    const params = useParams();
-    const searchValue = params.searchValue;
-
-    const { data: searchUsedProducts } = useQuery([PRODUCT_QUERY_KEY.SEARCH_PRODUCT_LIST, searchValue], () =>
-        Api.getSearchProduct(0, searchValue, 1)
-    );
-
-    console.log(searchUsedProducts);
-
-    const searchProductList = searchUsedProducts && searchUsedProducts.product;
-
-    // 데이터 패칭확인,
-    return (
-        searchProductList && (
-            <S.Wrapper>
-                {searchProductList.length === 0 || searchValue === 194191464161616511 ? (
-                    <NoResultPage />
-                ) : (
-                    <>
-                        <S.TitleWrapper>
-                            <SearchPageTitle totalProductsCount={searchProductList.length} searchValue={searchValue} />
-                        </S.TitleWrapper>
-                        <hr />
-                    </>
-                )}
-
-                <Container style={{ marginTop: 100 }}>
-                    <Grid container spacing={{ xs: 1, md: 2, lg: 3 }} style={{ paddingBottom: 20 }}>
-                        {searchProductList.map((product, index) => (
-                            <Grid key={index} product xs={12} md={4} lg={3} style={{ paddingBottom: 40 }}>
-                                <OneProduct
-                                    title={product.title}
-                                    content={product.content}
-                                    img={product.img_url}
-                                    price={product.price}
-                                    isLiked={product.isLiked}
-                                    status={product.status}
-                                    description={product.description}
-                                />
-                            </Grid>
-                        ))}
-                    </Grid>
-                </Container>
-            </S.Wrapper>
-        )
-    );
+        <Container style={{ marginTop: 100 }}>
+          <Grid
+            container
+            spacing={{ xs: 1, md: 2, lg: 3 }}
+            style={{ paddingBottom: 20 }}
+          >
+            {searchUsedProducts.pages?.map((page) => (
+              <>
+                {page.product?.map((product, index) => (
+                  <Grid
+                    key={index}
+                    product
+                    xs={12}
+                    md={4}
+                    lg={3}
+                    style={{ paddingBottom: 40 }}
+                  >
+                    <OneProduct
+                      title={product.title}
+                      img={product.img_url}
+                      price={product.price}
+                      isLiked={product.isLiked}
+                      status={product.status}
+                      likeCount={product.likeCount}
+                      id={product.id}
+                    />
+                  </Grid>
+                ))}
+              </>
+            ))}
+          </Grid>
+        </Container>
+        {/* 더 이상 불러올 상품이 없다면 MORE 버튼 안보이게 하는 조건 */}
+        {searchUsedProducts.pages[0].product.length && (
+          <>
+            {!(
+              searchUsedProducts.pages.at(-1).pagination.curPage ===
+              searchUsedProducts.pages[0].pagination.endPage
+            ) && (
+              <MMMButton
+                variant={"More"}
+                style={{ border: "1px solid #9F9EB3" }}
+                onClick={() => fetchNextPage()}
+              >
+                More
+              </MMMButton>
+            )}
+          </>
+        )}
+      </S.Wrapper>
+    )
+  );
 };
 export default SearchProductList;
 
 const Wrapper = styled.div`
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        padding-top: 80px;
-    }
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    padding-top: 80px;
+  }
 `;
 
 const TitleWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-    max-width: 1165px;
-    margin: 0 auto;
-    padding-top: 36px;
-    @media ${({ theme }) => theme.DEVICE.mobile} {
-        justify-content: flex-start;
-        flex-direction: column;
-        margin-left: 32px;
-    }
-    @media ${({ theme }) => theme.DEVICE.tablet} {
-        justify-content: flex-start;
-        flex-direction: column;
-        margin-left: 32px;
-    }
+  display: flex;
+  justify-content: space-between;
+  max-width: 1165px;
+  margin: 0 auto;
+  padding-top: 36px;
+  @media ${({ theme }) => theme.DEVICE.mobile} {
+    justify-content: flex-start;
+    flex-direction: column;
+    margin-left: 32px;
+  }
+  @media ${({ theme }) => theme.DEVICE.tablet} {
+    justify-content: flex-start;
+    flex-direction: column;
+    margin-left: 32px;
+  }
 `;
 
 const S = {
-    TitleWrapper,
-    Wrapper,
+  TitleWrapper,
+  Wrapper,
 };


### PR DESCRIPTION
상세내용
-> 전 commit에서는 백엔드 데이터 상품 개수를 몰라서 페이지 네이션으로 구현하려 했으나, 금일 데이터 확인 후 무한 스크롤 구현이 충분히 가능할 거 같아 기존 기획과 맞게 무한 스크롤 적용했습니다.

중고거래/무료나눔 페이지와 서치 페이지 useInfiniteQuery활용해서 무한 스크롤 적용했습니다.
header.js와 homePage에서 중고거래, 무료나눔 페이지로 이동하는 navigate함수에서 param값을 sell, free에서 백엔드 데이터에 맞게 0, 1로 바꿨습니다. (노션 api/product 3. 물품검색 내용 확인)

기획에 맞게 스크롤 최하단시 랜더 되는게 아니라, more 버튼 클릭 시 다음 페이지 불러오도록 했습니다.
(더 불러올 데이터가 없다면 more 버튼 안보이게 했습니다 + 검색 결과 없을 때)

활용한 라이브러리
-> X

발생한 문제 
-> X

향후 추가 할 내용
-> oneProduct에 content내용으로 쓸만한 데이터가 없어서 createdAt 데이터 활용해서 상품 등록 시간 표기 예정입니다.

>
>
Co-authored-by: kiminn <808010x@gmail.com>
Co-authored-by: LeeDaeGyeong <dleorud1027@gmail.com>
Co-authored-by: HeesikK <7jjhkhz@naver.com>