### PR TITLE
feat >> market-price page 그래프, detailpage 찜버튼

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -31,6 +31,20 @@ const getSearchProduct = async (category, keyword, pageParam) => {
   return res.data;
 };
 
+const postLikedProduct = async (id) => {
+  const res = await axiosInstance.post(`/api/product/like`, {
+    prod_idx: id,
+  });
+  return res.data;
+};
+
+const getMyPageLikeProduct = async (pageParam) => {
+  const res = await axiosInstance.get(
+    `/api/user/my-page/like-product-list?page=${pageParam}`
+  );
+  return res.data;
+};
+
 const getUsedProduct = async () => {
   const res = await axiosInstance.get("/products/sell");
   return res.data;
@@ -85,4 +99,6 @@ export const Api = {
   postUserData,
   getsignUserData,
   postRegistData,
+  postLikedProduct,
+  getMyPageLikeProduct,
 };

--- a/src/consts/index.js
+++ b/src/consts/index.js
@@ -10,5 +10,5 @@ export const PRODUCT_QUERY_KEY = {
   USER_DATA: "userData",
   SIGNUP_DATA: "signUpData",
   FULL_PRODUCT_LIST: "fullProductList",
-
+  LIKED_PRODUCT_DATA: "likedProductData",
 };

--- a/src/pages/detail-page/components/one-product-detail.js
+++ b/src/pages/detail-page/components/one-product-detail.js
@@ -7,11 +7,16 @@ import { faComments, faHeart } from "@fortawesome/free-solid-svg-icons";
 import { useNavigate } from "react-router-dom";
 import { UsePriceComma } from "hooks/use-price-comma";
 import { useParams } from "react-router-dom";
-import { useQuery } from "react-query";
+import {
+  useQuery,
+  useMutation,
+  QueryClient,
+  useQueryClient,
+} from "react-query";
 import { PRODUCT_QUERY_KEY } from "consts";
 import { Api } from "apis";
 import MannerTemperature from "components/manner-temperature";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const OneProductDetail = () => {
   const navigate = useNavigate();
@@ -21,12 +26,27 @@ const OneProductDetail = () => {
   const param = useParams();
   const dataId = param.id;
 
-  const { data: detailProduct } = useQuery(
+  const { data: detailProduct, refetch } = useQuery(
     [PRODUCT_QUERY_KEY.DETAIL_PRODUCT_DATA],
     () => Api.getDetailProduct(dataId)
   );
 
-  console.log(detailProduct);
+  const { mutate, data: LikedProductData } = useMutation((id) =>
+    Api.postLikedProduct(id)
+  );
+
+  console.log(LikedProductData);
+  const onClickLikedBtn = () => {
+    mutate(dataId);
+    if (LikedProductData && LikedProductData.message === true) {
+      alert("찜 취소");
+    } else if (
+      (LikedProductData && LikedProductData.message === false) ||
+      !LikedProductData
+    ) {
+      alert("찜");
+    }
+  };
 
   const onMarketPricePage = () => {
     const titleValue = detailProduct.searchProduct.title;
@@ -99,12 +119,17 @@ const OneProductDetail = () => {
                   </List>
                 </ul>
                 <ButtonBox>
-                  <MMMButton variant={"detailG"} size={"medium"}>
+                  <MMMButton
+                    variant={"detailG"}
+                    size={"medium"}
+                    onClick={onClickLikedBtn}
+                  >
                     <span>
                       <FontAwesomeIcon icon={faHeart} />
                     </span>{" "}
                     찜 {detailProduct.searchProduct.liked}
                   </MMMButton>
+
                   <MMMButton variant={"detailB"} size={"medium"}>
                     <FontAwesomeIcon icon={faComments} /> 채팅하기
                   </MMMButton>

--- a/src/pages/home-page/components/product-list.js
+++ b/src/pages/home-page/components/product-list.js
@@ -15,6 +15,8 @@ const ProductList = () => {
     () => Api.getMainProductList()
   );
 
+  console.log(productList);
+
   const UsedProductList = productList && productList.usedProduct;
   const FreeProductList = productList && productList.freeProduct;
 
@@ -48,7 +50,7 @@ const ProductList = () => {
                   img={item.img_url}
                   price={item.price}
                   isLiked={item.isLiked}
-                  id={item.id}
+                  id={item.idx}
                   status={item.status}
                 />
               </Grid>
@@ -85,7 +87,7 @@ const ProductList = () => {
                   img={item.img_url}
                   price={item.price}
                   isLiked={item.isLiked}
-                  id={item.id}
+                  id={item.idx}
                   status={item.status}
                 />
               </Grid>

--- a/src/pages/price-check-page/components/graph.js
+++ b/src/pages/price-check-page/components/graph.js
@@ -6,7 +6,6 @@ import { useQuery } from "react-query";
 import { PRODUCT_QUERY_KEY } from "consts";
 import { Api } from "apis";
 import { useParams } from "react-router-dom";
-import { useEffect, useState } from "react";
 
 const PriceGraph = () => {
   const today = new Date();
@@ -14,27 +13,19 @@ const PriceGraph = () => {
   aWeekAgo.setDate(today.getDate() - 4);
   // 5일간의 시세를 구하기 위한 오늘 날짜와 4일전 날짜
 
-  const [graphKeyWord, setGraphKeyWord] = useState("");
   const param = useParams();
-  const datatitle = param.title;
+  //const datatitle = param.title;
+  // titleparam값으로 해당 title의 상품 시세 검색
 
   const { data: ProductPriceList } = useQuery(
     [PRODUCT_QUERY_KEY.PRODUCT_PRICE_DATA],
     () =>
       Api.getProductPrice(
-        "",
+        "채팅방",
         aWeekAgo.toJSON().substr(0, 10),
         today.toJSON().substr(0, 10)
       )
   );
-
-  ProductPriceList && console.log(ProductPriceList, datatitle);
-
-  // useEffect(() => {
-  //   if (datatitle) {
-  //     setGraphKeyWord(datatitle);
-  //   }
-  // }, [datatitle]);
 
   // 월일만 출력하기 위해서 자름
   const sliceAvgPrice =
@@ -67,6 +58,7 @@ const PriceGraph = () => {
   const AVGARR =
     result && Math.floor(result / ProductPriceList.products.product.length);
 
+  //console.log(sliceAvgPrice, MAXARR, MINARR, AVGARR);
   //문제 배열안에서 가장 큰 값을 찾는 수식을 짜라 price가 가장 높은 애를 찾아라
 
   return (

--- a/src/pages/product-list-page/component/product-list.js
+++ b/src/pages/product-list-page/component/product-list.js
@@ -58,7 +58,7 @@ const ProductList = () => {
                       img={product.img_url}
                       price={product.price}
                       isLiked={product.isLiked}
-                      id={product.id}
+                      id={product.idx}
                       likeCount={product.likeCount}
                     />
                   </Grid>


### PR DESCRIPTION
market-price page의 그래프에서 이용하는 데이터를 임시적으로 특정 물품을 기준으로 적용시켜놓았습니다.
이유 => 알아보고 싶은 상품을 param 값으로 title을 전달받아 시세 API에 사용했으나 기존에 등록되어있던 상품은 잘 출력이 되는 것을 확인했습니다만 최근에 등록했던 상품 (ROLEX, 롤스로이드 등)은 출력에 오류가 있었습니다. 따라서 이 부분이 해소되기 전까지는 기존에 있던 특정 물품을 기준으로 사용해야할 것 같습니다.

detailpage 찜버튼의 찜기능을 활성화 시켰습니다.