### PR TITLE
feat >> logout backend API done

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "axios": "^1.5.1",
+        "axios": "^1.6.2",
         "msw": "^2.0.0",
         "react": "^18.2.0",
         "react-daum-postcode": "^3.1.3",
@@ -6989,9 +6989,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "axios": "^1.5.1",
+    "axios": "^1.6.2",
     "msw": "^2.0.0",
     "react": "^18.2.0",
     "react-daum-postcode": "^3.1.3",

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,7 +1,7 @@
 import { axiosInstance } from "./core";
 
 const getMainProductList = async () => {
-  const res = await axiosInstance.get(`/api/product`);
+  const res = await axiosInstance.get("/api/product");
   return res.data;
 };
 
@@ -65,12 +65,6 @@ const postMyChatData = async (bodyData) => {
   return res;
 };
 
-// get user info.
-const getUserData = async () => {
-  const res = await axiosInstance.get("/user");
-  return res.data;
-};
-
 // sign-up
 const postSignUpData = async (signupData) => {
   const res = await axiosInstance.post("/api/user", signupData);
@@ -82,15 +76,38 @@ const postLoginUserData = async (loginUserData) => {
   const res = await axiosInstance.post("/api/user/login", loginUserData);
   return res;
 };
-// logout
 
-// 이메일 중복 체크
+// get user info.
+const getUserData = async () => {
+  const res = await axiosInstance.get("/api/user/info");
+  return res.data;
+};
+
+// get my-page info.
+const getMyPageData = async () => {
+  const res = await axiosInstance.get("/api/user/my-page");
+  return res.data;
+};
+
+// patch user info.
+const patchUserData = async () => {
+  const res = await axiosInstance.patch("/api/user");
+  return res.data;
+};
+
+// logout
+const getUserLogout = async () => {
+  const res = await axiosInstance.get("/api/user/logout");
+  return res.data;
+};
+
+// duplicate check(email)
 const getCheckEmail = async (email) => {
   const res = await axiosInstance.get(`/api/user/check/email?email=${email}`);
   return res;
 };
 
-// 닉네임 중복 체크
+// duplicate check(nickName)
 const getCheckNickName = async (nickName) => {
   const res = await axiosInstance.get(
     `/api/user/check/nickname?nickname=${nickName}`
@@ -108,6 +125,7 @@ export const Api = {
   getDetailProduct,
   getUsedOrFreeProduct,
   getSearchProduct,
+  getFreeProduct,
   getBuyerChatData,
   postMyChatData,
   getUserData,
@@ -119,4 +137,11 @@ export const Api = {
   getCheckNickName,
   postLikedProduct,
   getMyPageLikeProduct,
+  postSignUpData,
+  postLoginUserData,
+  getCheckEmail,
+  getCheckNickName,
+  getMyPageData,
+  patchUserData,
+  getUserLogout,
 };

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -34,7 +34,6 @@ const variantCSS = {
       font-size: 16px;
     }
   `,
-
   detailY: css`
     background-color: #ffd02c;
     color: #fff;

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -14,7 +14,6 @@ const MMMInput = ({
     <InputBox>
       <label>{label}</label>
       <Input {...inputProps} size={size} />
-
       {isAvailableEmail || isAvailableNickName ? (
         <DuplicateChecked>
           {isAvailableEmail && <p>사용 가능한 이메일입니다</p>}

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -10,11 +10,14 @@ import close from "../../images/icon/close.png";
 import MenuBar from "./components/menu-bar";
 import { useRecoilState } from "recoil";
 import { isMenuBarState } from "store";
+import { useState } from "react";
+import MyPageModal from "components/my-page-Modal";
 
 const Header = () => {
   const navigate = useNavigate();
 
   const [isShowMenuBar, setIsShowMenuBar] = useRecoilState(isMenuBarState);
+  const [isMyPageModal, setIsMyPageModal] = useState(false);
 
   const onGoProductsListPage = (saleStatus) => {
     navigate(`/products/${saleStatus}`);
@@ -26,7 +29,8 @@ const Header = () => {
     navigate("/pricecheckpage");
   };
   const onGoMyPage = () => {
-    navigate("/my-page");
+    setIsMyPageModal((prev) => !prev);
+    console.log(isMyPageModal);
   };
 
   const onGoRegisterProductPage = () => {
@@ -34,7 +38,7 @@ const Header = () => {
   };
 
   const onOpenAndCloseMenuBar = () => {
-    setIsShowMenuBar((prev) => !prev);
+    setIsMyPageModal((prev) => !prev);
   };
 
   return (
@@ -50,6 +54,7 @@ const Header = () => {
       <S.RightIconContainer>
         <Search />
         <S.HeaderIcon src={user} alt="User" onClick={onGoMyPage} />
+        {isMyPageModal && <MyPageModal setIsMyPageModal={setIsMyPageModal} />}
         <S.HeaderIcon
           src={my_store}
           alt="myStore"

--- a/src/components/manner-temperature.js
+++ b/src/components/manner-temperature.js
@@ -10,8 +10,8 @@ import {
   faFaceLaughBeam,
 } from "@fortawesome/free-regular-svg-icons";
 
-const MannerTemperature = ({ user }) => {
-  const ratio = Math.floor((user.ondo / 100) * 100);
+const MannerTemperature = ({ temp }) => {
+  const ratio = Math.floor((temp.ondo / 100) * 100);
   const ratioColor =
     ratio <= 10
       ? "gray"
@@ -26,7 +26,7 @@ const MannerTemperature = ({ user }) => {
     <Manner>
       <Rate>
         <Celsius color={ratioColor}>
-          <p>{user.ondo}℃</p>
+          <p>{temp.ondo}℃</p>
         </Celsius>
         <Indicator>
           <Ratio ratio={ratio} color={ratioColor}></Ratio>

--- a/src/components/miniuser-Info.js
+++ b/src/components/miniuser-Info.js
@@ -1,26 +1,22 @@
 import { MockUserData } from "__mock__/faker-data";
 import styled from "styled-components";
 import { flexCenter } from "styles/common.style";
-import MannerTemperature from "./manner-temperature";
 import defaultProfile from "../images/defaultProfile.jpg";
 
-const UserInfo = ({ user, temp }) => {
+const MiniUserInfo = ({ user }) => {
   return (
     <Wrapper>
       <User>
         <Profile src={user.profileUrl ? user.profileUrl : defaultProfile} />
         <Text>
           <NickName>{user.nickName}</NickName>
-          {/* <Location>{user.region}</Location> */}
         </Text>
       </User>
-
-      <MannerTemperature temp={temp} />
     </Wrapper>
   );
 };
 
-export default UserInfo;
+export default MiniUserInfo;
 
 const Wrapper = styled.div`
   width: 100%;
@@ -34,8 +30,8 @@ const User = styled.div`
   flex-direction: row;
 `;
 const Profile = styled.img`
-  width: 120px;
-  height: 120px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   background-color: navy; // temporary color
   background-position: center;
@@ -49,8 +45,4 @@ const NickName = styled.h1`
   font-size: ${({ theme }) => theme.FONT_SIZE["larger"]};
   color: ${({ theme }) => theme.COLORS["black"]};
   margin-bottom: 4px;
-`;
-const Location = styled.h3`
-  font-size: ${({ theme }) => theme.FONT_SIZE["small"]};
-  color: ${({ theme }) => theme.COLORS.gray[400]};
 `;

--- a/src/components/my-page-Modal.js
+++ b/src/components/my-page-Modal.js
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { flexCenter } from "styles/common.style";
+import { useMutation, useQuery } from "react-query";
+import { Api } from "apis";
+import { PRODUCT_QUERY_KEY } from "consts";
+import MiniUserInfo from "./miniuser-Info";
+import { useNavigate } from "react-router-dom";
+
+const MyPageModal = ({ user, setIsMyPageModal }) => {
+  const navigate = useNavigate();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModalHandler = () => {
+    {
+      isModalOpen === true ? setIsModalOpen(false) : setIsModalOpen(true);
+    }
+  };
+  const { data: myPageData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_MY_PAGE_DATA],
+    () => Api.getMyPageData()
+  );
+  console.log("myPageData:", myPageData);
+  const { data: userLogoutData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_USER_LOGOUT_DATA],
+    () => Api.getUserLogout()
+  );
+
+  const mutation = useMutation(() => Api.getUserLogout());
+
+  const onClickLogout = async () => {
+    // axiosInstance.get("api/user/logout").then((response) => {
+    //   if (response.data.message === "success") {
+    //     // todo: 로그인 되어 있던 유저 정보 초기화 (MiniUserInfo)
+    //     navigate("/sign-in");
+    //     alert("로그아웃 되었습니다");
+    //     console.log("userLogoutData >>", userLogoutData);
+    //   } else {
+    //     alert("로그아웃에 실패했습니다");
+    //   }
+    // });
+
+    try {
+      const logoutUser = mutation.mutateAsync();
+      alert("로그아웃이 정상적으로 이뤄졌습니다.");
+      navigate("/sign-in");
+      console.log("logout success:", logoutUser);
+    } catch (error) {
+      console.log("logout error:", error);
+    }
+  };
+
+  const onClickMyPageBtn = () => {
+    navigate(`/my-page`);
+    setIsMyPageModal(false);
+  };
+
+  return (
+    myPageData && (
+      <>
+        <Wrapper>
+          <MiniUserInfo user={myPageData.User} />
+          <ButtonGroup>
+            <EventButton onClick={onClickMyPageBtn}>마이페이지</EventButton>
+            <EventButton onClick={onClickLogout}>로그아웃</EventButton>
+          </ButtonGroup>
+        </Wrapper>
+      </>
+    )
+  );
+};
+
+export default MyPageModal;
+
+const Wrapper = styled.div`
+  width: 240px;
+  height: 100px;
+  z-index: 100;
+  background: white;
+  box-shadow: 5px 5px 5px 5px rgba(0, 0, 0, 0.4);
+  border-radius: 6px;
+  position: absolute;
+  top: 70px;
+  right: 2%;
+  ${flexCenter}
+  flex-direction: column;
+`;
+
+const ButtonGroup = styled.div`
+  ${flexCenter}
+  flex-direction: row;
+  width: 80%;
+  margin-top: 10px;
+  justify-content: space-evenly;
+`;
+
+const EventButton = styled.button`
+  width: 70px;
+  height: 24px;
+  background-color: white;
+  border: 1px solid navy;
+  border-radius: 4px;
+  font-size: 10px;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: navy;
+    color: white;
+  }
+`;

--- a/src/components/one-product.js
+++ b/src/components/one-product.js
@@ -76,7 +76,6 @@ const OneProduct = ({ title, status, img, price, id, createdAt }) => {
       <S.Content className="Content">
         {ProductRegistrationTime(createdAt)}
       </S.Content>
-
       <S.Price className="Price">{price}원</S.Price>
     </S.Wrapper>
   );

--- a/src/consts/index.js
+++ b/src/consts/index.js
@@ -11,4 +11,6 @@ export const PRODUCT_QUERY_KEY = {
   SIGNUP_DATA: "signUpData",
   FULL_PRODUCT_LIST: "fullProductList",
   LIKED_PRODUCT_DATA: "likedProductData",
+  GET_MY_PAGE_DATA: "getMyPageData",
+  GET_USER_LOGOUT_DATA: "getUserLogoutData",
 };

--- a/src/pages/detail-page/components/one-product-detail.js
+++ b/src/pages/detail-page/components/one-product-detail.js
@@ -98,7 +98,7 @@ const OneProductDetail = () => {
                       </UserIdLoc>
                     </UserProfBox>
                     <MannerTemperature
-                      user={detailProduct.searchProduct.User.Ondo}
+                      temp={detailProduct.searchProduct.User.Ondo}
                     ></MannerTemperature>
                   </UserImgIdLoc>
                 </UserProf>
@@ -141,7 +141,6 @@ const OneProductDetail = () => {
                       ? "찜 했어요!"
                       : "찜 하기"}
                   </MMMButton>
-
                   <MMMButton variant={"detailB"} size={"medium"}>
                     <FontAwesomeIcon icon={faComments} /> 채팅하기
                   </MMMButton>
@@ -160,7 +159,6 @@ const OneProductDetail = () => {
             >
               More
             </MMMButton>
-
             {/*관련 상품 목록 */}
             <RelatedProduct>
               <span>연관상품</span>

--- a/src/pages/home-page/components/product-list.js
+++ b/src/pages/home-page/components/product-list.js
@@ -10,12 +10,19 @@ import MMMButton from "components/button";
 const ProductList = () => {
   const navigate = useNavigate();
 
+  const { data: myPageData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_MY_PAGE_DATA],
+    () => Api.getMyPageData()
+  );
+
+  myPageData && console.log("myPageData : ", myPageData);
+
   const { data: productList } = useQuery(
     [PRODUCT_QUERY_KEY.MORE_PRODUCT_LIST],
     () => Api.getMainProductList()
   );
 
-  console.log(productList);
+  productList && console.log(productList); // undefined
 
   const UsedProductList = productList && productList.usedProduct;
   const FreeProductList = productList && productList.freeProduct;

--- a/src/pages/login-page/components/signUp-form.js
+++ b/src/pages/login-page/components/signUp-form.js
@@ -222,7 +222,6 @@ const Form = styled.form`
     min-height: 46px;
     margin: 100px 0;
   }
-
   @media ${({ theme }) => theme.DEVICE.smallMobile} {
     max-width: 240px;
 
@@ -306,7 +305,6 @@ const OneRow = styled.div`
     font-weight: 600;
     margin-top: 20px;
   }
-
   @media ${({ theme }) => theme.DEVICE.smallMobile} {
     max-width: 240px;
 

--- a/src/pages/my-page/components/edit-account.js
+++ b/src/pages/my-page/components/edit-account.js
@@ -2,14 +2,15 @@ import MMMButton from "components/button";
 import MMMInput from "components/input";
 import { useState } from "react";
 import styled from "styled-components";
-import { flexAlignCenter, flexCenter } from "styles/common.style";
+import { flexCenter } from "styles/common.style";
 import defaultProfile from "../../../images/defaultProfile.jpg";
 import useInputs from "hooks/use-inputs";
-import { formValidate } from "utils/validate-helper";
+import { FormValidate } from "utils/validate-helper";
 
 const EditAccountInfo = ({ user }) => {
   // change profile image
   const [uploadedImage, setUploadedImage] = useState("");
+
   const onChangeImage = (e) => {
     const file = e.target.files[0];
     const imageUrl = URL.createObjectURL(file);
@@ -25,7 +26,7 @@ const EditAccountInfo = ({ user }) => {
     email: "",
     nickName: "",
   });
-  const { disabled, errors, access } = formValidate({
+  const { disabled, errors, access } = FormValidate({
     email,
     nickName,
   });
@@ -41,7 +42,7 @@ const EditAccountInfo = ({ user }) => {
           {uploadedImage ? (
             <Image src={uploadedImage} />
           ) : (
-            <Image src={user[0].profileImg} />
+            <Image src={user.profileUrl} />
           )}
           <ButtonWrap>
             <label htmlFor="imgUpload">변경하기</label>
@@ -62,7 +63,7 @@ const EditAccountInfo = ({ user }) => {
           name="nickName"
           label={"닉네임"}
           size={"editInfo"}
-          placeholder={user[0].nickName}
+          placeholder={user.nickName}
           onChange={onChangeInputs}
           error={errors.nickName}
           access={access.nickName}
@@ -71,7 +72,7 @@ const EditAccountInfo = ({ user }) => {
           name="email"
           label={"이메일 주소"}
           size={"editInfo"}
-          placeholder={user[0].email}
+          placeholder={user.email}
           onChange={onChangeInputs}
           error={errors.email}
           access={access.email}
@@ -80,14 +81,14 @@ const EditAccountInfo = ({ user }) => {
           name="phoneNumber"
           label={"핸드폰 번호"}
           size={"editInfo"}
-          placeholder={user[0].phoneNumber}
+          placeholder={user.phone}
           onChange={onChangeInputs}
         />
         <MMMInput
           name="location"
           label={"우리 동네"}
           size={"editInfo"}
-          placeholder={user[0].location}
+          placeholder={user.region}
           onChange={onChangeInputs}
         />
         <MMMButton size={"small"} type="submit" disabled={disabled}>

--- a/src/pages/my-page/index.js
+++ b/src/pages/my-page/index.js
@@ -1,21 +1,26 @@
 import styled from "styled-components";
-import { flexCenter } from "styles/common.style";
 import UserInfo from "components/user-Info";
 import TabList from "./components/tab-list";
-import { MockUserData } from "__mock__/faker-data";
+import { useQuery } from "react-query";
+import { PRODUCT_QUERY_KEY } from "consts";
+import { Api } from "apis";
 
 const MyPage = () => {
-  // getUserInfo. (temporary)
-  const user = MockUserData(1);
-  console.log("The user >>", user);
+  const { data: myPageData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_MY_PAGE_DATA],
+    () => Api.getMyPageData()
+  );
+  myPageData && console.log("myPageData : ", myPageData);
 
   return (
-    <Wrapper>
-      <UserContainer>
-        <UserInfo user={user} />
-      </UserContainer>
-      <TabList user={user} />
-    </Wrapper>
+    myPageData && (
+      <Wrapper>
+        <UserContainer>
+          <UserInfo user={myPageData.User} temp={myPageData} />
+        </UserContainer>
+        <TabList user={myPageData.User} />
+      </Wrapper>
+    )
   );
 };
 export default MyPage;

--- a/src/pages/price-check-page/components/graph.js
+++ b/src/pages/price-check-page/components/graph.js
@@ -6,6 +6,7 @@ import { useQuery } from "react-query";
 import { PRODUCT_QUERY_KEY } from "consts";
 import { Api } from "apis";
 import { useParams } from "react-router-dom";
+import { useState } from "react";
 
 const PriceGraph = () => {
   const today = new Date();
@@ -13,15 +14,16 @@ const PriceGraph = () => {
   aWeekAgo.setDate(today.getDate() - 4);
   // 5일간의 시세를 구하기 위한 오늘 날짜와 4일전 날짜
 
+  const [graphKeyWord, setGraphKeyWord] = useState("");
   const param = useParams();
-  //const datatitle = param.title;
-  // titleparam값으로 해당 title의 상품 시세 검색
+  const datatitle = param.title;
 
   const { data: ProductPriceList } = useQuery(
     [PRODUCT_QUERY_KEY.PRODUCT_PRICE_DATA],
     () =>
       Api.getProductPrice(
         "채팅방",
+        "",
         aWeekAgo.toJSON().substr(0, 10),
         today.toJSON().substr(0, 10)
       )

--- a/src/pages/product-list-page/component/product-list.js
+++ b/src/pages/product-list-page/component/product-list.js
@@ -60,7 +60,6 @@ const ProductList = () => {
                       id={product.idx}
                       likeCount={product.likeCount}
                       status={product.status}
-                      
                       createdAt={product.createdAt}
                     />
                   </Grid>

--- a/src/pages/search-page/components/search-product-list.js
+++ b/src/pages/search-page/components/search-product-list.js
@@ -71,6 +71,7 @@ const SearchProductList = () => {
                       status={product.status}
                       id={product.id}
                       createdAt={product.createdAt}
+                      /* likeCount={product.likeCount} */
                     />
                   </Grid>
                 ))}


### PR DESCRIPTION
[ 상세내용 ]
요약 : 로그인한 계정 정보 마이페이지에서 보여주기 && 로그아웃 기능 구현 완료

마이페이지에 적용되어 있던 msw 목데이터를 로그인한 유저의 정보로 보이도록 변경했습니다. 
( + component로 관리하는 user-info도 변경 완료했습니다.)

로그아웃 기능 구현 완료했습니다.
header에 있는 user-icon 클릭시 전에는 바로 마이페이지로 이동했던 부분을 modal이 뜨도록 변경했습니다.
modal 안에는 간단한 유저 정보와 마이페이지로 가는 버튼, 로그아웃할 수 있는 버튼이 포함되어 있습니다.


----------------------------------------------------------------------------------------------------------------------------


[ notice ]

1. 마이페이지 유저 정보에 주소 관련 데이터가 누락되어 있습니다.
백엔드에서 가져올 수 있는 유저 관련 데이터 중 "8.마이페이지 메인"에 region 정보가 없습니다.
처음에 피그마에서 디자인을 진행할 때 유저 닉네임 하단에 주소가 뜨도록 했었는데 이 부분을 데이터에 추가할지 디자인에서 제외할지 고민입니다.

2. modal 디자인 관련 
현재는 하얀 배경에 box-shadow로 디자인 되어 있습니다. 
혹시  그림자 대신 div에 테두리가 있는게 나을지 고민입니다. 어떤게 나을까요?


----------------------------------------------------------------------------------------------------------------------------


[ 향후 추가할 내용 ]

로그인/회원가입 관련 추가할 내용
- 중복확인 후 중복버튼 disabled (다시 못 누르도록 설정)
- 로그아웃 기능 추가 예정 ✅
- 라이브러리 변경(도로명 주소 관련) + 라이브러리 적용(alert 관련, toastify 라이브러리) 
- Token 관련 로직


----------------------------------------------------------------------------------------------------------------------------

Co-authored-by: Amy [[jyeon380516@gmail.com](mailto:jyeon380516@gmail.com)]
Co-authored-by: Jack [[wkdtkdwns2@gmail.com](mailto:wkdtkdwns2@gmail.com)]