### PR TITLE
Feat/backend/mypage/change info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mmm",
       "version": "0.1.0",
       "dependencies": {
+        "@apollo/client": "^3.8.7",
         "@chakra-ui/react": "^2.8.1",
         "@faker-js/faker": "^8.2.0",
         "@fortawesome/fontawesome-svg-core": "^6.4.2",
@@ -18,6 +19,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "@types/apollo-upload-client": "^17.0.5",
         "axios": "^1.6.2",
         "msw": "^2.0.0",
         "react": "^18.2.0",
@@ -74,6 +76,47 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.7.tgz",
+      "integrity": "sha512-DnQtFkQrCyxHTSa9gR84YRLmU/al6HeXcLZazVe+VxKBmx/Hj4rV8xWtzfWYX5ijartsqDR7SJgV037MATEecA==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.4.3",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.17.5",
+        "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3948,6 +3991,14 @@
         "react": ">=16.3"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -5629,6 +5680,16 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/apollo-upload-client": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/apollo-upload-client/-/apollo-upload-client-17.0.5.tgz",
+      "integrity": "sha512-rPKHaE4QNd06LNtBgz6hfntVO+pOQMS2yTcynrzBPg9+a/nbtJ2gus5KgzRp2rqfzmnKEc/sRGjLen/9Ot0Z2A==",
+      "dependencies": {
+        "@apollo/client": "^3.7.0",
+        "@types/extract-files": "*",
+        "graphql": "14 - 16"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.3.tgz",
@@ -5808,6 +5869,11 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/extract-files": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/extract-files/-/extract-files-8.1.3.tgz",
+      "integrity": "sha512-FQT1aXHL4NuSK44A9w3aFVG3p7q04uWnKNreGVoF0jno2SlWaMuaUjUZ6If0sVPEen3UVqYxdsEPJQLpvbkHEg=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.8",
@@ -6453,6 +6519,39 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -10933,6 +11032,20 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -11053,7 +11166,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -11061,8 +11173,7 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -15128,6 +15239,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.5.tgz",
+      "integrity": "sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==",
+      "dependencies": {
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -17769,6 +17890,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -19088,6 +19217,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -19406,6 +19543,17 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -20812,6 +20960,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "axios": "^1.5.1",
+        "axios": "^1.6.2",
         "msw": "^2.0.0",
         "react": "^18.2.0",
         "react-daum-postcode": "^3.1.3",
@@ -6989,9 +6989,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "axios": "^1.5.1",
+    "axios": "^1.6.2",
     "msw": "^2.0.0",
     "react": "^18.2.0",
     "react-daum-postcode": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@apollo/client": "^3.8.7",
     "@chakra-ui/react": "^2.8.1",
     "@faker-js/faker": "^8.2.0",
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
@@ -13,6 +14,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@types/apollo-upload-client": "^17.0.5",
     "axios": "^1.6.2",
     "msw": "^2.0.0",
     "react": "^18.2.0",

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -90,8 +90,16 @@ const getMyPageData = async () => {
 };
 
 // patch user info.
-const patchUserData = async () => {
-  const res = await axiosInstance.patch("/api/user");
+const patchUserData = async (myCurrentInfo) => {
+  const res = await axiosInstance.patch("/api/user", myCurrentInfo);
+  return res.data;
+};
+const patchUserProfile = async (uploadedImage) => {
+  const res = await axiosInstance.patch("/api/user/profile", uploadedImage);
+  return res.data;
+};
+const patchUserPassword = async (newPassword) => {
+  const res = await axiosInstance.patch("/api/user/password", newPassword);
   return res.data;
 };
 
@@ -113,6 +121,22 @@ const getCheckNickName = async (nickName) => {
     `/api/user/check/nickname?nickname=${nickName}`
   );
   return res;
+};
+
+// get my products list
+const getMyProductList = async (page, category) => {
+  const res = await axiosInstance.get(
+    `/api/user/my-page/product-list&page=${page}?category=${category}`
+  );
+  return res;
+};
+
+// get my interested products list
+const getInterestedProductList = async (page) => {
+  const res = await axiosInstance.get(
+    `/api/user/my-page/like-product-list?page=${page}`
+  );
+  return res.data;
 };
 
 const postRegistData = async (registData) => {
@@ -144,4 +168,8 @@ export const Api = {
   getMyPageData,
   patchUserData,
   getUserLogout,
+  patchUserProfile,
+  patchUserPassword,
+  getMyProductList,
+  getInterestedProductList,
 };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,7 +1,7 @@
 import { axiosInstance } from "./core";
 
 const getMainProductList = async () => {
-  const res = await axiosInstance.get(`/api/product`);
+  const res = await axiosInstance.get("/api/product");
   return res.data;
 };
 
@@ -65,12 +65,6 @@ const postMyChatData = async (bodyData) => {
   return res;
 };
 
-// get user info.
-const getUserData = async () => {
-  const res = await axiosInstance.get("/user");
-  return res.data;
-};
-
 // sign-up
 const postSignUpData = async (signupData) => {
   const res = await axiosInstance.post("/api/user", signupData);
@@ -82,15 +76,38 @@ const postLoginUserData = async (loginUserData) => {
   const res = await axiosInstance.post("/api/user/login", loginUserData);
   return res;
 };
-// logout
 
-// 이메일 중복 체크
+// get user info.
+const getUserData = async () => {
+  const res = await axiosInstance.get("/api/user/info");
+  return res.data;
+};
+
+// get my-page info.
+const getMyPageData = async () => {
+  const res = await axiosInstance.get("/api/user/my-page");
+  return res.data;
+};
+
+// patch user info.
+const patchUserData = async () => {
+  const res = await axiosInstance.patch("/api/user");
+  return res.data;
+};
+
+// logout
+const getUserLogout = async () => {
+  const res = await axiosInstance.get("/api/user/logout");
+  return res.data;
+};
+
+// duplicate check(email)
 const getCheckEmail = async (email) => {
   const res = await axiosInstance.get(`/api/user/check/email?email=${email}`);
   return res;
 };
 
-// 닉네임 중복 체크
+// duplicate check(nickName)
 const getCheckNickName = async (nickName) => {
   const res = await axiosInstance.get(
     `/api/user/check/nickname?nickname=${nickName}`
@@ -108,6 +125,7 @@ export const Api = {
   getDetailProduct,
   getUsedOrFreeProduct,
   getSearchProduct,
+  getFreeProduct,
   getBuyerChatData,
   postMyChatData,
   getUserData,
@@ -119,4 +137,11 @@ export const Api = {
   getCheckNickName,
   postLikedProduct,
   getMyPageLikeProduct,
+  postSignUpData,
+  postLoginUserData,
+  getCheckEmail,
+  getCheckNickName,
+  getMyPageData,
+  patchUserData,
+  getUserLogout,
 };

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -88,6 +88,12 @@ const sizeCSS = {
       height: 44px;
     }
   `,
+  smallConfirm: css`
+    min-width: 120px;
+    min-height: 46px;
+    border-radius: 4px;
+    margin-left: 20px;
+  `,
   confirm: css`
     min-width: 313px;
     min-height: 46px;

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -34,7 +34,6 @@ const variantCSS = {
       font-size: 16px;
     }
   `,
-
   detailY: css`
     background-color: #ffd02c;
     color: #fff;

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -86,7 +86,13 @@ const sizeCSS = {
       /* padding-bottom: 30px; */
     }
   `,
-
+  smallEditInfo: css`
+    min-width: 640px;
+    min-height: 48px;
+    border: none;
+    outline: none;
+    border-bottom: 1px solid ${({ theme }) => theme.COLORS.gray[300]};
+  `,
   editInfo: css`
     min-width: 780px;
     min-height: 48px;

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -14,7 +14,6 @@ const MMMInput = ({
     <InputBox>
       <label>{label}</label>
       <Input {...inputProps} size={size} />
-
       {isAvailableEmail || isAvailableNickName ? (
         <DuplicateChecked>
           {isAvailableEmail && <p>사용 가능한 이메일입니다</p>}

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -10,11 +10,14 @@ import close from "../../images/icon/close.png";
 import MenuBar from "./components/menu-bar";
 import { useRecoilState } from "recoil";
 import { isMenuBarState } from "store";
+import { useState } from "react";
+import MyPageModal from "components/my-page-Modal";
 
 const Header = () => {
   const navigate = useNavigate();
 
   const [isShowMenuBar, setIsShowMenuBar] = useRecoilState(isMenuBarState);
+  const [isMyPageModal, setIsMyPageModal] = useState(false);
 
   const onGoProductsListPage = (saleStatus) => {
     navigate(`/products/${saleStatus}`);
@@ -26,7 +29,8 @@ const Header = () => {
     navigate("/pricecheckpage");
   };
   const onGoMyPage = () => {
-    navigate("/my-page");
+    setIsMyPageModal((prev) => !prev);
+    console.log(isMyPageModal);
   };
 
   const onGoRegisterProductPage = () => {
@@ -34,7 +38,7 @@ const Header = () => {
   };
 
   const onOpenAndCloseMenuBar = () => {
-    setIsShowMenuBar((prev) => !prev);
+    setIsMyPageModal((prev) => !prev);
   };
 
   return (
@@ -50,6 +54,7 @@ const Header = () => {
       <S.RightIconContainer>
         <Search />
         <S.HeaderIcon src={user} alt="User" onClick={onGoMyPage} />
+        {isMyPageModal && <MyPageModal setIsMyPageModal={setIsMyPageModal} />}
         <S.HeaderIcon
           src={my_store}
           alt="myStore"

--- a/src/components/manner-temperature.js
+++ b/src/components/manner-temperature.js
@@ -10,8 +10,8 @@ import {
   faFaceLaughBeam,
 } from "@fortawesome/free-regular-svg-icons";
 
-const MannerTemperature = ({ user }) => {
-  const ratio = Math.floor((user.ondo / 100) * 100);
+const MannerTemperature = ({ temp }) => {
+  const ratio = Math.floor((temp.ondo / 100) * 100);
   const ratioColor =
     ratio <= 10
       ? "gray"
@@ -26,7 +26,7 @@ const MannerTemperature = ({ user }) => {
     <Manner>
       <Rate>
         <Celsius color={ratioColor}>
-          <p>{user.ondo}℃</p>
+          <p>{temp.ondo}℃</p>
         </Celsius>
         <Indicator>
           <Ratio ratio={ratio} color={ratioColor}></Ratio>

--- a/src/components/miniuser-Info.js
+++ b/src/components/miniuser-Info.js
@@ -1,26 +1,22 @@
 import { MockUserData } from "__mock__/faker-data";
 import styled from "styled-components";
 import { flexCenter } from "styles/common.style";
-import MannerTemperature from "./manner-temperature";
 import defaultProfile from "../images/defaultProfile.jpg";
 
-const UserInfo = ({ user, temp }) => {
+const MiniUserInfo = ({ user }) => {
   return (
     <Wrapper>
       <User>
         <Profile src={user.profileUrl ? user.profileUrl : defaultProfile} />
         <Text>
           <NickName>{user.nickName}</NickName>
-          {/* <Location>{user.region}</Location> */}
         </Text>
       </User>
-
-      <MannerTemperature temp={temp} />
     </Wrapper>
   );
 };
 
-export default UserInfo;
+export default MiniUserInfo;
 
 const Wrapper = styled.div`
   width: 100%;
@@ -34,8 +30,8 @@ const User = styled.div`
   flex-direction: row;
 `;
 const Profile = styled.img`
-  width: 120px;
-  height: 120px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   background-color: navy; // temporary color
   background-position: center;
@@ -49,8 +45,4 @@ const NickName = styled.h1`
   font-size: ${({ theme }) => theme.FONT_SIZE["larger"]};
   color: ${({ theme }) => theme.COLORS["black"]};
   margin-bottom: 4px;
-`;
-const Location = styled.h3`
-  font-size: ${({ theme }) => theme.FONT_SIZE["small"]};
-  color: ${({ theme }) => theme.COLORS.gray[400]};
 `;

--- a/src/components/my-page-Modal.js
+++ b/src/components/my-page-Modal.js
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { flexCenter } from "styles/common.style";
+import { useMutation, useQuery } from "react-query";
+import { Api } from "apis";
+import { PRODUCT_QUERY_KEY } from "consts";
+import MiniUserInfo from "./miniuser-Info";
+import { useNavigate } from "react-router-dom";
+
+const MyPageModal = ({ user, setIsMyPageModal }) => {
+  const navigate = useNavigate();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModalHandler = () => {
+    {
+      isModalOpen === true ? setIsModalOpen(false) : setIsModalOpen(true);
+    }
+  };
+  const { data: myPageData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_MY_PAGE_DATA],
+    () => Api.getMyPageData()
+  );
+  console.log("myPageData:", myPageData);
+  const { data: userLogoutData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_USER_LOGOUT_DATA],
+    () => Api.getUserLogout()
+  );
+
+  const mutation = useMutation(() => Api.getUserLogout());
+
+  const onClickLogout = async () => {
+    // axiosInstance.get("api/user/logout").then((response) => {
+    //   if (response.data.message === "success") {
+    //     // todo: 로그인 되어 있던 유저 정보 초기화 (MiniUserInfo)
+    //     navigate("/sign-in");
+    //     alert("로그아웃 되었습니다");
+    //     console.log("userLogoutData >>", userLogoutData);
+    //   } else {
+    //     alert("로그아웃에 실패했습니다");
+    //   }
+    // });
+
+    try {
+      const logoutUser = mutation.mutateAsync();
+      alert("로그아웃이 정상적으로 이뤄졌습니다.");
+      navigate("/sign-in");
+      console.log("logout success:", logoutUser);
+    } catch (error) {
+      console.log("logout error:", error);
+    }
+  };
+
+  const onClickMyPageBtn = () => {
+    navigate(`/my-page`);
+    setIsMyPageModal(false);
+  };
+
+  return (
+    myPageData && (
+      <>
+        <Wrapper>
+          <MiniUserInfo user={myPageData.User} />
+          <ButtonGroup>
+            <EventButton onClick={onClickMyPageBtn}>마이페이지</EventButton>
+            <EventButton onClick={onClickLogout}>로그아웃</EventButton>
+          </ButtonGroup>
+        </Wrapper>
+      </>
+    )
+  );
+};
+
+export default MyPageModal;
+
+const Wrapper = styled.div`
+  width: 240px;
+  height: 100px;
+  z-index: 100;
+  background: white;
+  box-shadow: 5px 5px 5px 5px rgba(0, 0, 0, 0.4);
+  border-radius: 6px;
+  position: absolute;
+  top: 70px;
+  right: 2%;
+  ${flexCenter}
+  flex-direction: column;
+`;
+
+const ButtonGroup = styled.div`
+  ${flexCenter}
+  flex-direction: row;
+  width: 80%;
+  margin-top: 10px;
+  justify-content: space-evenly;
+`;
+
+const EventButton = styled.button`
+  width: 70px;
+  height: 24px;
+  background-color: white;
+  border: 1px solid navy;
+  border-radius: 4px;
+  font-size: 10px;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: navy;
+    color: white;
+  }
+`;

--- a/src/components/my-page-Modal.js
+++ b/src/components/my-page-Modal.js
@@ -29,17 +29,6 @@ const MyPageModal = ({ user, setIsMyPageModal }) => {
   const mutation = useMutation(() => Api.getUserLogout());
 
   const onClickLogout = async () => {
-    // axiosInstance.get("api/user/logout").then((response) => {
-    //   if (response.data.message === "success") {
-    //     // todo: 로그인 되어 있던 유저 정보 초기화 (MiniUserInfo)
-    //     navigate("/sign-in");
-    //     alert("로그아웃 되었습니다");
-    //     console.log("userLogoutData >>", userLogoutData);
-    //   } else {
-    //     alert("로그아웃에 실패했습니다");
-    //   }
-    // });
-
     try {
       const logoutUser = mutation.mutateAsync();
       alert("로그아웃이 정상적으로 이뤄졌습니다.");

--- a/src/components/one-product.js
+++ b/src/components/one-product.js
@@ -76,7 +76,6 @@ const OneProduct = ({ title, status, img, price, id, createdAt }) => {
       <S.Content className="Content">
         {ProductRegistrationTime(createdAt)}
       </S.Content>
-
       <S.Price className="Price">{price}원</S.Price>
     </S.Wrapper>
   );

--- a/src/components/user-Info.js
+++ b/src/components/user-Info.js
@@ -1,4 +1,3 @@
-import { MockUserData } from "__mock__/faker-data";
 import styled from "styled-components";
 import { flexCenter } from "styles/common.style";
 import MannerTemperature from "./manner-temperature";
@@ -14,7 +13,6 @@ const UserInfo = ({ user, temp }) => {
           {/* <Location>{user.region}</Location> */}
         </Text>
       </User>
-
       <MannerTemperature temp={temp} />
     </Wrapper>
   );

--- a/src/consts/index.js
+++ b/src/consts/index.js
@@ -13,4 +13,8 @@ export const PRODUCT_QUERY_KEY = {
   LIKED_PRODUCT_DATA: "likedProductData",
   GET_MY_PAGE_DATA: "getMyPageData",
   GET_USER_LOGOUT_DATA: "getUserLogoutData",
+  PATCH_USER_DATA: "patchUserData",
+  PATCH_USER_PROFILE: "patchUserProfile",
+  GET_MY_PRODUCT_LIST: "getMyProductList",
+  GET_INTERESTED_PRODUCT_LIST: "getInterestedProductList",
 };

--- a/src/consts/index.js
+++ b/src/consts/index.js
@@ -11,4 +11,6 @@ export const PRODUCT_QUERY_KEY = {
   SIGNUP_DATA: "signUpData",
   FULL_PRODUCT_LIST: "fullProductList",
   LIKED_PRODUCT_DATA: "likedProductData",
+  GET_MY_PAGE_DATA: "getMyPageData",
+  GET_USER_LOGOUT_DATA: "getUserLogoutData",
 };

--- a/src/pages/detail-page/components/one-product-detail.js
+++ b/src/pages/detail-page/components/one-product-detail.js
@@ -98,7 +98,7 @@ const OneProductDetail = () => {
                       </UserIdLoc>
                     </UserProfBox>
                     <MannerTemperature
-                      user={detailProduct.searchProduct.User.Ondo}
+                      temp={detailProduct.searchProduct.User.Ondo}
                     ></MannerTemperature>
                   </UserImgIdLoc>
                 </UserProf>
@@ -141,7 +141,6 @@ const OneProductDetail = () => {
                       ? "찜 했어요!"
                       : "찜 하기"}
                   </MMMButton>
-
                   <MMMButton variant={"detailB"} size={"medium"}>
                     <FontAwesomeIcon icon={faComments} /> 채팅하기
                   </MMMButton>
@@ -160,7 +159,6 @@ const OneProductDetail = () => {
             >
               More
             </MMMButton>
-
             {/*관련 상품 목록 */}
             <RelatedProduct>
               <span>연관상품</span>

--- a/src/pages/home-page/components/product-list.js
+++ b/src/pages/home-page/components/product-list.js
@@ -22,7 +22,7 @@ const ProductList = () => {
     () => Api.getMainProductList()
   );
 
-  productList && console.log(productList); // undefined
+  productList && console.log(productList);
 
   const UsedProductList = productList && productList.usedProduct;
   const FreeProductList = productList && productList.freeProduct;

--- a/src/pages/home-page/components/product-list.js
+++ b/src/pages/home-page/components/product-list.js
@@ -10,12 +10,19 @@ import MMMButton from "components/button";
 const ProductList = () => {
   const navigate = useNavigate();
 
+  const { data: myPageData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_MY_PAGE_DATA],
+    () => Api.getMyPageData()
+  );
+
+  myPageData && console.log("myPageData : ", myPageData);
+
   const { data: productList } = useQuery(
     [PRODUCT_QUERY_KEY.MORE_PRODUCT_LIST],
     () => Api.getMainProductList()
   );
 
-  console.log(productList);
+  productList && console.log(productList); // undefined
 
   const UsedProductList = productList && productList.usedProduct;
   const FreeProductList = productList && productList.freeProduct;

--- a/src/pages/login-page/components/signUp-form.js
+++ b/src/pages/login-page/components/signUp-form.js
@@ -141,6 +141,7 @@ const SignUpForm = () => {
           type="password"
           placeholder="비밀번호 확인"
           error={errors.pwConfirm}
+          access={access.pwConfirm}
           onChange={onChangeInputs}
           size={"full"}
           required

--- a/src/pages/login-page/components/signUp-form.js
+++ b/src/pages/login-page/components/signUp-form.js
@@ -222,7 +222,6 @@ const Form = styled.form`
     min-height: 46px;
     margin: 100px 0;
   }
-
   @media ${({ theme }) => theme.DEVICE.smallMobile} {
     max-width: 240px;
 
@@ -306,7 +305,6 @@ const OneRow = styled.div`
     font-weight: 600;
     margin-top: 20px;
   }
-
   @media ${({ theme }) => theme.DEVICE.smallMobile} {
     max-width: 240px;
 

--- a/src/pages/my-page/components/edit-account.js
+++ b/src/pages/my-page/components/edit-account.js
@@ -2,14 +2,15 @@ import MMMButton from "components/button";
 import MMMInput from "components/input";
 import { useState } from "react";
 import styled from "styled-components";
-import { flexAlignCenter, flexCenter } from "styles/common.style";
+import { flexCenter } from "styles/common.style";
 import defaultProfile from "../../../images/defaultProfile.jpg";
 import useInputs from "hooks/use-inputs";
-import { formValidate } from "utils/validate-helper";
+import { FormValidate } from "utils/validate-helper";
 
 const EditAccountInfo = ({ user }) => {
   // change profile image
   const [uploadedImage, setUploadedImage] = useState("");
+
   const onChangeImage = (e) => {
     const file = e.target.files[0];
     const imageUrl = URL.createObjectURL(file);
@@ -25,7 +26,7 @@ const EditAccountInfo = ({ user }) => {
     email: "",
     nickName: "",
   });
-  const { disabled, errors, access } = formValidate({
+  const { disabled, errors, access } = FormValidate({
     email,
     nickName,
   });
@@ -41,7 +42,7 @@ const EditAccountInfo = ({ user }) => {
           {uploadedImage ? (
             <Image src={uploadedImage} />
           ) : (
-            <Image src={user[0].profileImg} />
+            <Image src={user.profileUrl} />
           )}
           <ButtonWrap>
             <label htmlFor="imgUpload">변경하기</label>
@@ -62,7 +63,7 @@ const EditAccountInfo = ({ user }) => {
           name="nickName"
           label={"닉네임"}
           size={"editInfo"}
-          placeholder={user[0].nickName}
+          placeholder={user.nickName}
           onChange={onChangeInputs}
           error={errors.nickName}
           access={access.nickName}
@@ -71,7 +72,7 @@ const EditAccountInfo = ({ user }) => {
           name="email"
           label={"이메일 주소"}
           size={"editInfo"}
-          placeholder={user[0].email}
+          placeholder={user.email}
           onChange={onChangeInputs}
           error={errors.email}
           access={access.email}
@@ -80,14 +81,14 @@ const EditAccountInfo = ({ user }) => {
           name="phoneNumber"
           label={"핸드폰 번호"}
           size={"editInfo"}
-          placeholder={user[0].phoneNumber}
+          placeholder={user.phone}
           onChange={onChangeInputs}
         />
         <MMMInput
           name="location"
           label={"우리 동네"}
           size={"editInfo"}
-          placeholder={user[0].location}
+          placeholder={user.region}
           onChange={onChangeInputs}
         />
         <MMMButton size={"small"} type="submit" disabled={disabled}>

--- a/src/pages/my-page/components/interested-product.js
+++ b/src/pages/my-page/components/interested-product.js
@@ -1,25 +1,52 @@
 import styled from "styled-components";
-import { Grid, GridItem } from "@chakra-ui/react";
 import { useQuery } from "react-query";
 import { Api } from "apis";
 import { PRODUCT_QUERY_KEY } from "consts";
-import { worker } from "__mock__/browser";
+import { Container, Grid } from "@mui/material";
+import { useNavigate } from "react-router-dom";
 
 const InterestedProducts = ({ user }) => {
+  const { data: getInterestedProductList } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_INTERESTED_PRODUCT_LIST],
+    () => Api.getInterestedProductList(1)
+  );
+  console.log("getInterest", getInterestedProductList);
+
+  const navigate = useNavigate();
+
+  const onToDetailPage = (id) => {
+    navigate(`/products/detail/${id}`);
+    window.scrollTo({ top: 0 });
+  };
+
   return (
-    <Wrapper>
-      <Grid templateColumns="repeat(3, 1fr)" gap={20}>
-        <GridItem>{/* <OneImage img={item.Product_img} /> */}</GridItem>
-      </Grid>
-    </Wrapper>
+    getInterestedProductList && (
+      <Wrapper>
+        <Container style={{ marginTop: 100 }}>
+          <Grid
+            container
+            spacing={{ xs: 1, md: 2, lg: 3 }}
+            style={{ paddingBottom: 20 }}
+          >
+            {getInterestedProductList.data.LikeList.map((list, index) => (
+              <Grid style={{ margin: 2 }}>
+                <OneImage
+                  src={list.Product.img_url}
+                  onClick={() => onToDetailPage(list.Product.idx)}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      </Wrapper>
+    )
   );
 };
 export default InterestedProducts;
 
 const Wrapper = styled.div``;
-
 const OneImage = styled.img`
   background-color: lightgray;
-  width: 380px;
-  height: 380px;
+  width: 330px;
+  height: 330px;
 `;

--- a/src/pages/my-page/components/password-change.js
+++ b/src/pages/my-page/components/password-change.js
@@ -1,25 +1,79 @@
+import { Api } from "apis";
 import MMMButton from "components/button";
 import MMMInput from "components/input";
+import useInputs from "hooks/use-inputs";
+import { useState } from "react";
+import { useMutation } from "react-query";
 import styled from "styled-components";
 import { flexAlignCenter } from "styles/common.style";
+import { FormValidate } from "utils/validate-helper";
 
 const ChangePassword = () => {
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  // validate check
+  const [{ pw, pwConfirm }, onChangeInputs] = useInputs({
+    pw: "",
+    pwConfirm: "",
+  });
+  const { errors, access } = FormValidate({
+    pw,
+    pwConfirm,
+  });
+
+  // change password
+  const { mutateAsync: mutateChangePassword, data: changePasswordData } =
+    useMutation((newPassword) => Api.patchUserPassword(newPassword));
+
+  // patch password
+  const onEditPassword = async (e) => {
+    e.preventDefault();
+    const newPasswordConfirm = e.target.pwConfirm.value;
+    const newPassword = e.target.pw.value;
+    const patchPassword = {
+      pw: newPassword,
+    };
+
+    if (newPassword === newPasswordConfirm) {
+      try {
+        await mutateChangePassword(patchPassword);
+        alert("비밀번호 변경에 성공하셨습니다!");
+      } catch (error) {
+        error && alert("비밀번호 변경에 실패했습니다");
+      }
+    } else {
+      alert("비밀번호가 일치하는지 확인해주세요!");
+    }
+  };
+
   return (
     <Wrapper>
       <Title>비밀번호 변경</Title>
-      <Contents>
-        <MMMInput label={"비밀번호"} size={"editInfo"} placeholder="password" />
+      <Contents onSubmit={onEditPassword}>
+        {/* <MMMInput label={"비밀번호"} type="password" name="pw" size={"editInfo"} placeholder="password" onChange={onChangeInputs}/> */}
         <MMMInput
           label={"새 비밀번호"}
+          type="password"
+          name="pw"
           size={"editInfo"}
           placeholder="new password"
+          onChange={onChangeInputs}
+          error={errors.pw}
+          access={access.pw}
         />
         <MMMInput
           label={"새 비밀번호 확인"}
+          type="password"
+          name="pwConfirm"
           size={"editInfo"}
           placeholder="confirm new password"
+          onChange={onChangeInputs}
+          error={errors.pwConfirm}
+          access={access.pwConfirm}
         />
-        <MMMButton size={"small"}>변경사항 저장</MMMButton>
+        <MMMButton size={"small"} type="submit" disabled={isDisabled}>
+          변경사항 저장
+        </MMMButton>
       </Contents>
     </Wrapper>
   );

--- a/src/pages/my-page/components/purchased-product.js
+++ b/src/pages/my-page/components/purchased-product.js
@@ -1,7 +1,41 @@
+import { Container, Grid } from "@mui/material";
+import { Api } from "apis";
+import { PRODUCT_QUERY_KEY } from "consts";
+import { useQuery } from "react-query";
 import styled from "styled-components";
 
 const PurchasedProducts = () => {
-  return <Wrapper>구매한 제품 목록</Wrapper>;
+  // getMyProductList
+  const { data: getMyProductList } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_MY_PRODUCT_LIST],
+    () => Api.getMyProductList(1, 1)
+  );
+
+  // getInterestedProductList
+
+  return (
+    getMyProductList && (
+      <Wrapper>
+        구매한 제품 목록
+        <Container>
+          {/* <Grid
+          container
+          spacing={{ xs: 1, md: 2, lg: 3 }}
+          style={{ paddingBottom: 20 }}
+        >
+          <Grid
+            key={index}
+            item
+            xs={12}
+            md={4}
+            lg={3}
+            style={{ paddingBottom: 40 }}
+          ></Grid>
+        </Grid> */}
+        </Container>
+      </Wrapper>
+    )
+  );
 };
 export default PurchasedProducts;
 

--- a/src/pages/my-page/index.js
+++ b/src/pages/my-page/index.js
@@ -10,7 +10,6 @@ const MyPage = () => {
     [PRODUCT_QUERY_KEY.GET_MY_PAGE_DATA],
     () => Api.getMyPageData()
   );
-  myPageData && console.log("myPageData : ", myPageData);
 
   return (
     myPageData && (

--- a/src/pages/my-page/index.js
+++ b/src/pages/my-page/index.js
@@ -1,21 +1,26 @@
 import styled from "styled-components";
-import { flexCenter } from "styles/common.style";
 import UserInfo from "components/user-Info";
 import TabList from "./components/tab-list";
-import { MockUserData } from "__mock__/faker-data";
+import { useQuery } from "react-query";
+import { PRODUCT_QUERY_KEY } from "consts";
+import { Api } from "apis";
 
 const MyPage = () => {
-  // getUserInfo. (temporary)
-  const user = MockUserData(1);
-  console.log("The user >>", user);
+  const { data: myPageData } = useQuery(
+    [PRODUCT_QUERY_KEY.GET_MY_PAGE_DATA],
+    () => Api.getMyPageData()
+  );
+  myPageData && console.log("myPageData : ", myPageData);
 
   return (
-    <Wrapper>
-      <UserContainer>
-        <UserInfo user={user} />
-      </UserContainer>
-      <TabList user={user} />
-    </Wrapper>
+    myPageData && (
+      <Wrapper>
+        <UserContainer>
+          <UserInfo user={myPageData.User} temp={myPageData} />
+        </UserContainer>
+        <TabList user={myPageData.User} />
+      </Wrapper>
+    )
   );
 };
 export default MyPage;

--- a/src/pages/price-check-page/components/graph.js
+++ b/src/pages/price-check-page/components/graph.js
@@ -6,6 +6,7 @@ import { useQuery } from "react-query";
 import { PRODUCT_QUERY_KEY } from "consts";
 import { Api } from "apis";
 import { useParams } from "react-router-dom";
+import { useState } from "react";
 
 const PriceGraph = () => {
   const today = new Date();
@@ -13,15 +14,16 @@ const PriceGraph = () => {
   aWeekAgo.setDate(today.getDate() - 4);
   // 5일간의 시세를 구하기 위한 오늘 날짜와 4일전 날짜
 
+  const [graphKeyWord, setGraphKeyWord] = useState("");
   const param = useParams();
-  //const datatitle = param.title;
-  // titleparam값으로 해당 title의 상품 시세 검색
+  const datatitle = param.title;
 
   const { data: ProductPriceList } = useQuery(
     [PRODUCT_QUERY_KEY.PRODUCT_PRICE_DATA],
     () =>
       Api.getProductPrice(
         "채팅방",
+        "",
         aWeekAgo.toJSON().substr(0, 10),
         today.toJSON().substr(0, 10)
       )

--- a/src/pages/product-list-page/component/product-list.js
+++ b/src/pages/product-list-page/component/product-list.js
@@ -60,7 +60,6 @@ const ProductList = () => {
                       id={product.idx}
                       likeCount={product.likeCount}
                       status={product.status}
-                      
                       createdAt={product.createdAt}
                     />
                   </Grid>

--- a/src/pages/search-page/components/search-product-list.js
+++ b/src/pages/search-page/components/search-product-list.js
@@ -71,6 +71,7 @@ const SearchProductList = () => {
                       status={product.status}
                       id={product.id}
                       createdAt={product.createdAt}
+                      /* likeCount={product.likeCount} */
                     />
                   </Grid>
                 ))}

--- a/src/utils/validate-helper.js
+++ b/src/utils/validate-helper.js
@@ -6,12 +6,14 @@ export const FormValidate = ({
   phone,
   region,
 }) => {
+  // sign-in
   let disabled =
     !/^[0-9a-zA-Z]([-_|.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_|.]?[0-9a-zA-Z])*|.[a-zA-Z]{2,3}$/.test(
       email
     ) || !/^[a-z0-9]+$/.test(pw);
 
   if (pwConfirm) {
+    // sign-up
     disabled =
       disabled ||
       (pw !== pwConfirm &&


### PR DESCRIPTION
[ 상세내용 ]
요약 : 마이페이지에서 개인정보 수정 (이메일, 닉네임, 전화번호, 주소, 비밀번호) && 관심상품 목록 보여주기 완성

마이페이지에서 개인정보 수정 부분 완료했습니다. 
백엔드 데이터가 프로필 이미지는 따로 요청을 하도록 되어 있어 외부 라이브러리 활용해 물품 등록 부분과 함께 따로 PR 요청할 예정입니다.

관심상품 목록 보여주기 완료했습니다.
3페어에서 작성하신 것과 거의 동일하게 Grid 사용해 화면 크기가 줄어듦에 따라 3열 > 2열 > 1열로 보이도록 했습니다. 


----------------------------------------------------------------------------------------------------------------------------

[ notice ]
- 개인정보 : 프로필 이미지 변경
백엔드 데이터가 프로필 이미지는 따로 요청을 하도록 되어 있어 외부 라이브러리 활용해 물품 등록 부분과 함께 따로 PR 요청할 예정입니다.

- 현재 비밀번호 가져오는 부분 백엔드 요청 필요
현재 개인 정보와 비교해 업데이트를 해야 하는데 유저의 현재 비밀번호를 가져올 수 있는 api가 없어서 다음 주 월요일 요청드려야 할 것 같습니다.

----------------------------------------------------------------------------------------------------------------------------

[ 향후 추가할 내용 ]

마이페이지 관련 추가할 내용

- 이미지를 백엔드로 보내는 외부 라이브러리 사용 (물품 등록 및 프로필 변경에 적용)
-  내가 등록한 물품 목록 보여주기
- 가계부 보여주기
- 비밀번호 관련 로직 추가 (현재 비밀번호와 비교하는 부분)
- 채팅 완성되면 탭 클릭 시 내 채팅목록 띄워주기

----------------------------------------------------------------------------------------------------------------------------


Co-authored-by: Amy [[jyeon380516@gmail.com](mailto:jyeon380516@gmail.com)]
Co-authored-by: Jack [[wkdtkdwns2@gmail.com](mailto:wkdtkdwns2@gmail.com)]